### PR TITLE
feat: enable CUDA 13.0 cross compilation

### DIFF
--- a/HOW_TO_UPDATE.md
+++ b/HOW_TO_UPDATE.md
@@ -7,16 +7,16 @@ In what follows, we present the basic steps needed:
 *Additional changes were needed for the creation of deb packages
 
 ```bash
-export CUMM_CUDA_VERSION=12.8
+export CUMM_CUDA_VERSION=13.0
 export CUMM_DISABLE_JIT=1
 export SPCONV_DISABLE_JIT=1
-# CUMM does not list 10.1 in cumm/common.py
+# CUMM does not list 10.1/11.0 in cumm/common.py
 export CUMM_CUDA_ARCH_LIST="7.5 8.0 8.6 8.7 8.9 9.0 10.0 12.0"
 
 git clone https://github.com/traveller59/spconv.git && git clone https://github.com/FindDefinition/cumm
 pip install pccm
 
-cd cumm && git checkout v0.8.2 && python3 setup.py bdist_wheel && pip3 install dist/cumm_cu128-0.8.2-cp310-cp310-linux_x86_64.whl
+cd cumm && git checkout v0.8.2 && python3 setup.py bdist_wheel && pip3 install dist/cumm_cu130-0.8.2-cp310-cp310-linux_x86_64.whl
 
 cmake . -B ./build && \
     cmake --build ./build --config Release --parallel $(nproc)

--- a/README.md
+++ b/README.md
@@ -6,12 +6,22 @@ This repository is a pre-generated version of the [spconv](https://github.com/tr
 The versions used to generate this code are:
  - cumm: 0.5.3
  - spconv: 2.3.8
- - CUDA: 12.8
- - architecture list: 7.5 8.0 8.6 8.7 8.9 9.0 10.0 10.1 12.0
+ - CUDA: 13.0
+ - architecture list: 7.5 8.0 8.6 8.7 8.9 9.0 10.0 10.1/11.0 12.0
 
 Note: CUDA Toolkit 13.0 renamed the SM101 for Thor GPUs to SM110.
 
 # Compilation and package generation
+
+Here is a way to use a NVIDIA CUDA Docker image for compilation. Feel free to use your own environment.
+```bash
+docker pull nvidia/cuda:13.0.2-devel-ubuntu24.04
+git clone https://github.com/autowarefoundation/spconv_cpp
+cd spconv_cpp
+docker run -it --rm --gpus all -v .:/workspace nvidia/cuda:13.0.2-devel-ubuntu24.04 bash
+cd /workspace
+apt update && apt install -y cmake wget
+```
 
 ## Native compilation and installation
 
@@ -20,51 +30,33 @@ Note: CUDA Toolkit 13.0 renamed the SM101 for Thor GPUs to SM110.
 mkdir -p cumm/build-amd64 && cd cumm/build-amd64 && cmake .. && make && cpack -G DEB
 
 # The package is generated in cumm/_packages/cumm_0.5.3_amd64.deb
-cd ../../ && sudo apt-get install ./cumm/_packages/cumm_0.5.3_amd64.deb
+cd ../../ && apt install ./cumm/_packages/cumm_0.5.3_amd64.deb
 
 # spconv
 mkdir -p spconv/build-amd64 && cd spconv/build-amd64 && cmake .. && make -j $(nproc) && cpack -G DEB
 
 # The package is generated in spconv/_packages/spconv_2.3.8_amd64.deb
-cd ../../ && sudo apt-get install ./spconv/_packages/spconv_2.3.8_amd64.deb
+cd ../../ && apt install ./spconv/_packages/spconv_2.3.8_amd64.deb
 ```
 
 ## Cross compilation for ARM64
 
-### SBSA
+Note: Jetson Thor is based on the SBSA stack, so we can use the SBSA toolchain for cross compilation.
 
 ```bash
 # Install cross compilation tools
-sudo apt-get install gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
+apt install gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
 
 # Install CUDA cross compilation toolkit
-wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/cross-linux-sbsa/cuda-keyring_1.1-1_all.deb
-sudo dpkg -i cuda-keyring_1.1-1_all.deb
-sudo apt-get update && sudo apt-get install cuda-cross-sbsa=12.8.1-1
+wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/cross-linux-sbsa/cuda-keyring_1.1-1_all.deb
+dpkg -i cuda-keyring_1.1-1_all.deb
+apt update && apt install -y cuda-cross-sbsa=13.0.2-1
 
 # cumm
 mkdir -p cumm/build-arm64 && cd cumm/build-arm64 && cmake .. -DCMAKE_TOOLCHAIN_FILE=../../extras/arm64-toolchain.cmake && make && cpack -G DEB && cd ../..
 
 # spconv
 mkdir -p spconv/build-arm64 && cd spconv/build-arm64 && cmake .. -DCMAKE_TOOLCHAIN_FILE=../../extras/arm64-toolchain.cmake && make -j $(nproc) && cpack -G DEB && cd ../..
-```
-
-### Jetson
-
-```bash
-# Install cross compilation tools
-sudo apt-get install gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
-
-# Install CUDA cross compilation toolkit
-wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/cross-linux-aarch64/cuda-keyring_1.1-1_all.deb
-sudo dpkg -i cuda-keyring_1.1-1_all.deb
-sudo apt-get update && sudo apt-get install cuda-cross-aarch64=12.8.1-1
-
-# cumm
-mkdir -p cumm/build-arm64 && cd cumm/build-arm64 && cmake .. -DCMAKE_TOOLCHAIN_FILE=../../extras/arm64-toolchain.cmake -DARM64_CUDA_TARGET=aarch64-linux && make && cpack -G DEB && cd ../..
-
-# spconv
-mkdir -p spconv/build-arm64 && cd spconv/build-arm64 && cmake .. -DCMAKE_TOOLCHAIN_FILE=../../extras/arm64-toolchain.cmake -DARM64_CUDA_TARGET=aarch64-linux && make -j $(nproc) && cpack -G DEB && cd ../..
 ```
 
 # License

--- a/cumm/cmake/Packing.cmake
+++ b/cumm/cmake/Packing.cmake
@@ -25,12 +25,7 @@ set(CPACK_RESOURCE_FILE_README "${CMAKE_CURRENT_SOURCE_DIR}/README.md")
 # Detect architecture for cross-compilation
 if(CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64|arm64")
     set(CPACK_DEBIAN_PACKAGE_ARCHITECTURE "arm64")
-    # Custom suffix for filename differentiation
-    if(ARM64_CUDA_TARGET STREQUAL "aarch64-linux")
-      set(ARCH_SUFFIX "arm64-jetson")
-    else()
-      set(ARCH_SUFFIX "arm64-sbsa")
-    endif()
+    set(ARCH_SUFFIX "arm64")
 elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64|amd64")
     set(CPACK_DEBIAN_PACKAGE_ARCHITECTURE "amd64")
     set(ARCH_SUFFIX "amd64")

--- a/cumm/include/tensorview/cuda/arch_defs.h
+++ b/cumm/include/tensorview/cuda/arch_defs.h
@@ -27,8 +27,14 @@ enum _Arch {
   kSm75 = 75, // RTX 2000
   kSm80 = 80, // A100
   kSm86 = 86, // RTX 3000
-  kSm87 = 87, // orin
+  kSm87 = 87, // Orin
+  kSm89 = 89, // RTX 4000
   kSm80 = 90, // H100
+  kSm100 = 100, // B200
+  kSm101 = 101, // Thor (for CUDA <13.0)
+  kSm103 = 103, // B300
+  kSm110 = 110, // Thor (for CUDA >=13.0)
+  kSm120 = 120, // Blackwell
   kEnd = 999999
 };
 }

--- a/extras/arm64-toolchain.cmake
+++ b/extras/arm64-toolchain.cmake
@@ -5,24 +5,33 @@ set(CMAKE_SYSTEM_PROCESSOR aarch64)
 set(CMAKE_C_COMPILER aarch64-linux-gnu-gcc)
 set(CMAKE_CXX_COMPILER aarch64-linux-gnu-g++)
 
-# For CUDA cross-compilation
+# For CUDA cross-compilation (SBSA; covers Jetson Thor and other ARM64 CUDA platforms)
 set(CMAKE_CUDA_COMPILER /usr/local/cuda/bin/nvcc)
 set(CMAKE_CUDA_HOST_COMPILER ${CMAKE_CXX_COMPILER})
 
-# Allow user to specify ARM64 variant: sbsa-linux (server) or aarch64-linux (Jetson)
-set(ARM64_CUDA_TARGET "sbsa-linux" CACHE STRING "ARM64 CUDA target: sbsa-linux or aarch64-linux")
-set_property(CACHE ARM64_CUDA_TARGET PROPERTY STRINGS "sbsa-linux" "aarch64-linux")
-
-# Set architectures based on target
-if(ARM64_CUDA_TARGET STREQUAL "aarch64-linux")
-    # Jetson architectures
-    set(CMAKE_CUDA_ARCHITECTURES "87;101" CACHE STRING "CUDA architectures for Jetson")
+# Detect CUDA version from nvcc (CUDA 13.0+ uses sm_110 instead of sm_101)
+execute_process(
+    COMMAND ${CMAKE_CUDA_COMPILER} --version
+    OUTPUT_VARIABLE _nvcc_out
+    ERROR_VARIABLE _nvcc_err
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+)
+string(REGEX MATCH "release ([0-9]+)\\.([0-9]+)" _nvcc_match "${_nvcc_out}")
+if(CMAKE_MATCH_1)
+    set(_CUDA_VERSION_DETECTED "${CMAKE_MATCH_1}.${CMAKE_MATCH_2}")
+    message(STATUS "arm64-toolchain: detected CUDA version from nvcc: ${_CUDA_VERSION_DETECTED}")
 else()
-    # Server/datacenter architectures
-    set(CMAKE_CUDA_ARCHITECTURES "75;80;86;87;89;90;100;101;120" CACHE STRING "CUDA architectures for SBSA")
+    message(FATAL_ERROR "arm64-toolchain.cmake: could not detect CUDA version from nvcc. Ensure ${CMAKE_CUDA_COMPILER} exists and returns a parseable --version (e.g. \"release 13.0\").")
 endif()
 
-set(CUDA_TARGET_INCLUDE_PATH "/usr/local/cuda/targets/${ARM64_CUDA_TARGET}/include")
+set(CMAKE_CUDA_ARCHITECTURES "75;80;86;87;89;90;100;120" CACHE STRING "CUDA architectures for ARM64 (SBSA)")
+if(_CUDA_VERSION_DETECTED VERSION_LESS "13.0")
+    list(APPEND CMAKE_CUDA_ARCHITECTURES "101")
+else()
+    list(APPEND CMAKE_CUDA_ARCHITECTURES "110")
+endif()
+
+set(CUDA_TARGET_INCLUDE_PATH "/usr/local/cuda/targets/sbsa-linux/include")
 set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -I${CUDA_TARGET_INCLUDE_PATH}")
 
 # Search for programs in the build host directories

--- a/spconv/cmake/Packing.cmake
+++ b/spconv/cmake/Packing.cmake
@@ -25,12 +25,7 @@ set(CPACK_RESOURCE_FILE_README "${CMAKE_CURRENT_SOURCE_DIR}/README.md")
 # Detect architecture for cross-compilation
 if(CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64|arm64")
     set(CPACK_DEBIAN_PACKAGE_ARCHITECTURE "arm64")
-    # Custom suffix for filename differentiation
-    if(ARM64_CUDA_TARGET STREQUAL "aarch64-linux")
-      set(ARCH_SUFFIX "arm64-jetson")
-    else()
-      set(ARCH_SUFFIX "arm64-sbsa")
-    endif()
+    set(ARCH_SUFFIX "arm64")
 elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64|amd64")
     set(CPACK_DEBIAN_PACKAGE_ARCHITECTURE "amd64")
     set(ARCH_SUFFIX "amd64")


### PR DESCRIPTION
This PR enables cross-compilation with CUDA 13.0 and fulfills Jetpack 7.0 support as addressed in https://github.com/autowarefoundation/spconv_cpp/pull/7.
Note: Jetson Thor is based on the SBSA stack therefore we don't need to deploy sbsa/aarch64 binaries separately anymore.