### PR TITLE
Fix compatibility issues for NVIDIA DRIVE AGX Thor devkit

### DIFF
--- a/cumm/include/tensorview/tensor.h
+++ b/cumm/include/tensorview/tensor.h
@@ -170,9 +170,16 @@ struct is_convertible<T, __nv_bfloat16>: std::is_floating_point<T> {};
 template <typename T> class TensorStorage {
   friend Tensor;
 public:
+#ifdef TV_CUDA
+  TensorStorage(size_t size, int device = -1, bool managed = false,
+                bool pinned = false, cudaStream_t stream = nullptr)
+      : size_(size), device_(device), managed_(managed), pinned_(pinned),
+        stream_(stream) {
+#else
   TensorStorage(size_t size, int device = -1, bool managed = false,
                 bool pinned = false)
       : size_(size), device_(device), managed_(managed), pinned_(pinned) {
+#endif
     if (size == 0) {
       ptr_ = nullptr;
     } else {
@@ -191,7 +198,7 @@ public:
         if (managed) {
           checkCudaErrors(cudaMallocManaged(&this->ptr_, size * sizeof(T)));
         } else {
-          checkCudaErrors(cudaMalloc(&ptr_, size * sizeof(T)));
+          checkCudaErrors(cudaMallocAsync(&ptr_, size * sizeof(T), stream_));
         }
 #else
         TV_THROW_INVALID_ARG("don't compiled with cuda");
@@ -223,7 +230,7 @@ public:
       }
     } else {
 #ifdef TV_CUDA
-      cudaFree(ptr_);
+      cudaFreeAsync(ptr_, stream_);
 #endif
     }
   };
@@ -352,6 +359,9 @@ private:
   int device_ = -1;
   bool managed_ = false;
   bool pinned_ = false;
+#ifdef TV_CUDA
+  cudaStream_t stream_ = nullptr;
+#endif
 };
 
 template <typename T> size_t sizeof_dtype(T dtype) {
@@ -650,10 +660,34 @@ using TensorShape = ShapeBase<kTensorMaxDim, int64_t>;
 struct Tensor {
   // empty tensor will have float32 dtype by default.
   Tensor(): dtype_(tv::float32) {}
+#ifdef TV_CUDA
+  Tensor(TensorShape shape, TensorShape stride, DType dtype, int device = -1,
+         bool pinned = false, bool managed = false,
+         cudaStream_t stream = nullptr)
+      : dtype_(dtype) {
+    // TV_ASSERT_INVALID_ARG(!shape.empty(), "dont support empty shape");
+    storage_ = std::make_shared<detail::TensorStorage<uint8_t>>(
+        shape.size() * detail::sizeof_dtype(dtype), device, managed, pinned, stream);
+    shape_ = shape;
+    stride_ = stride;
+    contiguous_ = compute_is_contiguous();
+    TV_ASSERT_RT_ERR(contiguous_, "stride must be contiguous when you create tensor from shape");
+  }
+
+  Tensor(TensorShape shape, DType dtype, int device = -1, bool pinned = false,
+         bool managed = false, cudaStream_t stream = nullptr)
+      : dtype_(dtype) {
+    // TV_ASSERT_INVALID_ARG(!shape.empty(), "dont support empty shape");
+    storage_ = std::make_shared<detail::TensorStorage<uint8_t>>(
+        shape.size() * detail::sizeof_dtype(dtype), device, managed, pinned, stream);
+    shape_ = shape;
+    stride_ = shape.stride_rowmajor();
+    contiguous_ = compute_is_contiguous();
+  }
+#else
   Tensor(TensorShape shape, TensorShape stride, DType dtype, int device = -1,
          bool pinned = false, bool managed = false)
       : dtype_(dtype) {
-    
     // TV_ASSERT_INVALID_ARG(!shape.empty(), "dont support empty shape");
     storage_ = std::make_shared<detail::TensorStorage<uint8_t>>(
         shape.size() * detail::sizeof_dtype(dtype), device, managed, pinned);
@@ -673,6 +707,7 @@ struct Tensor {
     stride_ = shape.stride_rowmajor();
     contiguous_ = compute_is_contiguous();
   }
+#endif
   Tensor(void *ptr, TensorShape shape, TensorShape stride, DType dtype,
          int device = -1)
       : dtype_(dtype) {

--- a/cumm/include/tensorview/tensor.h
+++ b/cumm/include/tensorview/tensor.h
@@ -170,16 +170,9 @@ struct is_convertible<T, __nv_bfloat16>: std::is_floating_point<T> {};
 template <typename T> class TensorStorage {
   friend Tensor;
 public:
-#ifdef TV_CUDA
-  TensorStorage(size_t size, int device = -1, bool managed = false,
-                bool pinned = false, cudaStream_t stream = nullptr)
-      : size_(size), device_(device), managed_(managed), pinned_(pinned),
-        stream_(stream) {
-#else
   TensorStorage(size_t size, int device = -1, bool managed = false,
                 bool pinned = false)
       : size_(size), device_(device), managed_(managed), pinned_(pinned) {
-#endif
     if (size == 0) {
       ptr_ = nullptr;
     } else {
@@ -198,7 +191,7 @@ public:
         if (managed) {
           checkCudaErrors(cudaMallocManaged(&this->ptr_, size * sizeof(T)));
         } else {
-          checkCudaErrors(cudaMallocAsync(&ptr_, size * sizeof(T), stream_));
+          checkCudaErrors(cudaMalloc(&ptr_, size * sizeof(T)));
         }
 #else
         TV_THROW_INVALID_ARG("don't compiled with cuda");
@@ -230,7 +223,7 @@ public:
       }
     } else {
 #ifdef TV_CUDA
-      cudaFreeAsync(ptr_, stream_);
+      cudaFree(ptr_);
 #endif
     }
   };
@@ -359,9 +352,6 @@ private:
   int device_ = -1;
   bool managed_ = false;
   bool pinned_ = false;
-#ifdef TV_CUDA
-  cudaStream_t stream_ = nullptr;
-#endif
 };
 
 template <typename T> size_t sizeof_dtype(T dtype) {
@@ -660,34 +650,10 @@ using TensorShape = ShapeBase<kTensorMaxDim, int64_t>;
 struct Tensor {
   // empty tensor will have float32 dtype by default.
   Tensor(): dtype_(tv::float32) {}
-#ifdef TV_CUDA
-  Tensor(TensorShape shape, TensorShape stride, DType dtype, int device = -1,
-         bool pinned = false, bool managed = false,
-         cudaStream_t stream = nullptr)
-      : dtype_(dtype) {
-    // TV_ASSERT_INVALID_ARG(!shape.empty(), "dont support empty shape");
-    storage_ = std::make_shared<detail::TensorStorage<uint8_t>>(
-        shape.size() * detail::sizeof_dtype(dtype), device, managed, pinned, stream);
-    shape_ = shape;
-    stride_ = stride;
-    contiguous_ = compute_is_contiguous();
-    TV_ASSERT_RT_ERR(contiguous_, "stride must be contiguous when you create tensor from shape");
-  }
-
-  Tensor(TensorShape shape, DType dtype, int device = -1, bool pinned = false,
-         bool managed = false, cudaStream_t stream = nullptr)
-      : dtype_(dtype) {
-    // TV_ASSERT_INVALID_ARG(!shape.empty(), "dont support empty shape");
-    storage_ = std::make_shared<detail::TensorStorage<uint8_t>>(
-        shape.size() * detail::sizeof_dtype(dtype), device, managed, pinned, stream);
-    shape_ = shape;
-    stride_ = shape.stride_rowmajor();
-    contiguous_ = compute_is_contiguous();
-  }
-#else
   Tensor(TensorShape shape, TensorShape stride, DType dtype, int device = -1,
          bool pinned = false, bool managed = false)
       : dtype_(dtype) {
+
     // TV_ASSERT_INVALID_ARG(!shape.empty(), "dont support empty shape");
     storage_ = std::make_shared<detail::TensorStorage<uint8_t>>(
         shape.size() * detail::sizeof_dtype(dtype), device, managed, pinned);
@@ -707,7 +673,7 @@ struct Tensor {
     stride_ = shape.stride_rowmajor();
     contiguous_ = compute_is_contiguous();
   }
-#endif
+
   Tensor(void *ptr, TensorShape shape, TensorShape stride, DType dtype,
          int device = -1)
       : dtype_(dtype) {

--- a/cumm/include/tensorview/tensor.h
+++ b/cumm/include/tensorview/tensor.h
@@ -653,7 +653,7 @@ struct Tensor {
   Tensor(TensorShape shape, TensorShape stride, DType dtype, int device = -1,
          bool pinned = false, bool managed = false)
       : dtype_(dtype) {
-
+    
     // TV_ASSERT_INVALID_ARG(!shape.empty(), "dont support empty shape");
     storage_ = std::make_shared<detail::TensorStorage<uint8_t>>(
         shape.size() * detail::sizeof_dtype(dtype), device, managed, pinned);
@@ -673,7 +673,6 @@ struct Tensor {
     stride_ = shape.stride_rowmajor();
     contiguous_ = compute_is_contiguous();
   }
-
   Tensor(void *ptr, TensorShape shape, TensorShape stride, DType dtype,
          int device = -1)
       : dtype_(dtype) {

--- a/spconv/src/spconvlib/cumm/common/CompileInfo/CompileInfo_arch_is_compiled_gemm.cc
+++ b/spconv/src/spconvlib/cumm/common/CompileInfo/CompileInfo_arch_is_compiled_gemm.cc
@@ -26,6 +26,9 @@ bool CompileInfo::arch_is_compiled_gemm(std::tuple<int, int> arch)   {
   if (arch == std::make_tuple(10, 0)){
       return true;
   }
+  if (arch == std::make_tuple(10, 1)){
+      return true;
+  }
   if (arch == std::make_tuple(11, 0)){
       return true;
   }

--- a/spconv/src/spconvlib/spconv/csrc/sparse/all/SpconvOps/SpconvOps_sort_1d_by_key_allocator_v2.cu
+++ b/spconv/src/spconvlib/spconv/csrc/sparse/all/SpconvOps/SpconvOps_sort_1d_by_key_allocator_v2.cu
@@ -114,19 +114,23 @@ tv::Tensor SpconvOps::sort_1d_by_key_allocator_v2(tv::Tensor data, ThrustAllocat
   if (mask_count == 1) {
     // Use CUB radix sort (CUDA graph capture compatible)
     if (data.dtype() == tv::DType(1)){
-      cub_sort_pairs(data.data_ptr<int32_t>(), indices.data_ptr<int32_t>(),
+      using T_ = int32_t;
+      cub_sort_pairs(data.data_ptr<T_>(), indices.data_ptr<int32_t>(),
                      num_items, allocator, stream_cu);
     }
     else if (data.dtype() == tv::DType(8)){
-      cub_sort_pairs(data.data_ptr<int64_t>(), indices.data_ptr<int32_t>(),
+      using T_ = int64_t;
+      cub_sort_pairs(data.data_ptr<T_>(), indices.data_ptr<int32_t>(),
                      num_items, allocator, stream_cu);
     }
     else if (data.dtype() == tv::DType(10)){
-      cub_sort_pairs(data.data_ptr<uint32_t>(), indices.data_ptr<int32_t>(),
+      using T_ = uint32_t;
+      cub_sort_pairs(data.data_ptr<T_>(), indices.data_ptr<int32_t>(),
                      num_items, allocator, stream_cu);
     }
     else if (data.dtype() == tv::DType(11)){
-      cub_sort_pairs(data.data_ptr<uint64_t>(), indices.data_ptr<int32_t>(),
+      using T_ = uint64_t;
+      cub_sort_pairs(data.data_ptr<T_>(), indices.data_ptr<int32_t>(),
                      num_items, allocator, stream_cu);
     }
     else{

--- a/spconv/src/spconvlib/spconv/csrc/sparse/all/SpconvOps/SpconvOps_sort_1d_by_key_allocator_v2.cu
+++ b/spconv/src/spconvlib/spconv/csrc/sparse/all/SpconvOps/SpconvOps_sort_1d_by_key_allocator_v2.cu
@@ -118,7 +118,6 @@ tv::Tensor SpconvOps::sort_1d_by_key_allocator_v2(tv::Tensor data, ThrustAllocat
   if (!do_sort){
       return indices;
   }
-  // auto timer = tv::CUDATimer();
 
   int num_items = data.dim(0);
 
@@ -142,7 +141,7 @@ tv::Tensor SpconvOps::sort_1d_by_key_allocator_v2(tv::Tensor data, ThrustAllocat
       });
     });
   }
-  // tv::ssprint("SORT BY KEY TIME", data.dim(0), timer.report() / 1000.0);
+
   return indices;
 }
 } // namespace all

--- a/spconv/src/spconvlib/spconv/csrc/sparse/all/SpconvOps/SpconvOps_sort_1d_by_key_allocator_v2.cu
+++ b/spconv/src/spconvlib/spconv/csrc/sparse/all/SpconvOps/SpconvOps_sort_1d_by_key_allocator_v2.cu
@@ -95,6 +95,17 @@ void cub_sort_pairs(KeyT* keys, int32_t* values, int num_items,
   allocator.deallocate(workspace, total_bytes);
 }
 
+template <typename Func>
+void dispatch_dtype(tv::Tensor& data, Func&& func) {
+  if (data.dtype() == tv::DType(1))       { func(data.data_ptr<int32_t>()); }
+  else if (data.dtype() == tv::DType(8))  { func(data.data_ptr<int64_t>()); }
+  else if (data.dtype() == tv::DType(10)) { func(data.data_ptr<uint32_t>()); }
+  else if (data.dtype() == tv::DType(11)) { func(data.data_ptr<uint64_t>()); }
+  else {
+    TV_THROW_RT_ERR("unknown dtype, available: [int32_t, int64_t, uint32_t, uint64_t]");
+  }
+}
+
 }  // namespace
 
 tv::Tensor SpconvOps::sort_1d_by_key_allocator_v2(tv::Tensor data, ThrustAllocator& allocator, tv::Tensor indices, std::uintptr_t stream, int mask_count, bool do_sort)   {
@@ -113,79 +124,23 @@ tv::Tensor SpconvOps::sort_1d_by_key_allocator_v2(tv::Tensor data, ThrustAllocat
 
   if (mask_count == 1) {
     // Use CUB radix sort (CUDA graph capture compatible)
-    if (data.dtype() == tv::DType(1)){
-      using T_ = int32_t;
-      cub_sort_pairs(data.data_ptr<T_>(), indices.data_ptr<int32_t>(),
+    dispatch_dtype(data, [&](auto* keys) {
+      cub_sort_pairs(keys, indices.data_ptr<int32_t>(),
                      num_items, allocator, stream_cu);
-    }
-    else if (data.dtype() == tv::DType(8)){
-      using T_ = int64_t;
-      cub_sort_pairs(data.data_ptr<T_>(), indices.data_ptr<int32_t>(),
-                     num_items, allocator, stream_cu);
-    }
-    else if (data.dtype() == tv::DType(10)){
-      using T_ = uint32_t;
-      cub_sort_pairs(data.data_ptr<T_>(), indices.data_ptr<int32_t>(),
-                     num_items, allocator, stream_cu);
-    }
-    else if (data.dtype() == tv::DType(11)){
-      using T_ = uint64_t;
-      cub_sort_pairs(data.data_ptr<T_>(), indices.data_ptr<int32_t>(),
-                     num_items, allocator, stream_cu);
-    }
-    else{
-      TV_THROW_RT_ERR("unknown dtype data.dtype(), available: [int32_t, int64_t, uint32_t, uint64_t]")
-    }
-  }
-  else {
+    });
+  } else {
     // mask_count > 1: fall back to thrust (rare case for kernel_volume > 32)
-    if (data.dtype() == tv::DType(1)){
-      using T_ = int32_t;
+    dispatch_dtype(data, [&](auto* keys) {
+      using T_ = std::remove_pointer_t<decltype(keys)>;
       tv::dispatch_int<1, 2, 3, 4>(mask_count, [&](auto IV){
           constexpr int I = TV_DECLTYPE(IV)::value;
           using T = tv::mp_rename<tv::mp_repeat_c<tv::mp_list<T_>, I>, thrust::tuple>;
-          thrust::device_ptr<T> ptr_tr(reinterpret_cast<T*>(data.data_ptr<T_>()));
+          thrust::device_ptr<T> ptr_tr(reinterpret_cast<T*>(keys));
           thrust::device_ptr<int32_t> ptr_k(indices.data_ptr<int32_t>());
           auto ctx2 = thrust::cuda::par(allocator).on(stream_cu);
           thrust::sort_by_key(ctx2, ptr_tr, ptr_tr + data.dim(0), ptr_k);
       });
-    }
-    else if (data.dtype() == tv::DType(8)){
-      using T_ = int64_t;
-      tv::dispatch_int<1, 2, 3, 4>(mask_count, [&](auto IV){
-          constexpr int I = TV_DECLTYPE(IV)::value;
-          using T = tv::mp_rename<tv::mp_repeat_c<tv::mp_list<T_>, I>, thrust::tuple>;
-          thrust::device_ptr<T> ptr_tr(reinterpret_cast<T*>(data.data_ptr<T_>()));
-          thrust::device_ptr<int32_t> ptr_k(indices.data_ptr<int32_t>());
-          auto ctx2 = thrust::cuda::par(allocator).on(stream_cu);
-          thrust::sort_by_key(ctx2, ptr_tr, ptr_tr + data.dim(0), ptr_k);
-      });
-    }
-    else if (data.dtype() == tv::DType(10)){
-      using T_ = uint32_t;
-      tv::dispatch_int<1, 2, 3, 4>(mask_count, [&](auto IV){
-          constexpr int I = TV_DECLTYPE(IV)::value;
-          using T = tv::mp_rename<tv::mp_repeat_c<tv::mp_list<T_>, I>, thrust::tuple>;
-          thrust::device_ptr<T> ptr_tr(reinterpret_cast<T*>(data.data_ptr<T_>()));
-          thrust::device_ptr<int32_t> ptr_k(indices.data_ptr<int32_t>());
-          auto ctx2 = thrust::cuda::par(allocator).on(stream_cu);
-          thrust::sort_by_key(ctx2, ptr_tr, ptr_tr + data.dim(0), ptr_k);
-      });
-    }
-    else if (data.dtype() == tv::DType(11)){
-      using T_ = uint64_t;
-      tv::dispatch_int<1, 2, 3, 4>(mask_count, [&](auto IV){
-          constexpr int I = TV_DECLTYPE(IV)::value;
-          using T = tv::mp_rename<tv::mp_repeat_c<tv::mp_list<T_>, I>, thrust::tuple>;
-          thrust::device_ptr<T> ptr_tr(reinterpret_cast<T*>(data.data_ptr<T_>()));
-          thrust::device_ptr<int32_t> ptr_k(indices.data_ptr<int32_t>());
-          auto ctx2 = thrust::cuda::par(allocator).on(stream_cu);
-          thrust::sort_by_key(ctx2, ptr_tr, ptr_tr + data.dim(0), ptr_k);
-      });
-    }
-    else{
-      TV_THROW_RT_ERR("unknown dtype data.dtype(), available: [int32_t, int64_t, uint32_t, uint64_t]")
-    }
+    });
   }
   // tv::ssprint("SORT BY KEY TIME", data.dim(0), timer.report() / 1000.0);
   return indices;

--- a/spconv/src/spconvlib/spconv/csrc/sparse/all/SpconvOps/SpconvOps_sort_1d_by_key_allocator_v2.cu
+++ b/spconv/src/spconvlib/spconv/csrc/sparse/all/SpconvOps/SpconvOps_sort_1d_by_key_allocator_v2.cu
@@ -2,6 +2,7 @@
 #include <spconvlib/spconv/csrc/sparse/all/CustomThrustLib.h>
 #include <spconvlib/cumm/common/TensorViewKernel.h>
 #include <spconvlib/spconv/csrc/sparse/all/cudakers/CudaCommonKernel.h>
+#include <cub/cub.cuh>
 namespace spconvlib {
 namespace spconv {
 namespace csrc {
@@ -25,8 +26,63 @@ using SpconvIndicesCPU4D = spconvlib::spconv::csrc::sparse::all::ops_cpu4d::Spar
 using Point2Voxel4D = spconvlib::spconv::csrc::sparse::all::ops4d::Point2Voxel;
 using CustomThrustLib = spconvlib::spconv::csrc::sparse::all::CustomThrustLib;
 using TensorViewKernel = spconvlib::cumm::common::TensorViewKernel;
+
+namespace {
+
+constexpr size_t kAlignment = 256;
+
+inline size_t align_up(size_t n, size_t alignment) {
+  return (n + alignment - 1) & ~(alignment - 1);
+}
+
+template <typename KeyT>
+void cub_sort_pairs(KeyT* keys, int32_t* values, int num_items,
+                    ThrustAllocator& allocator, cudaStream_t stream) {
+  // Query temp storage size
+  size_t temp_bytes = 0;
+  cub::DeviceRadixSort::SortPairs(
+      nullptr, temp_bytes,
+      static_cast<const KeyT*>(nullptr), static_cast<KeyT*>(nullptr),
+      static_cast<const int32_t*>(nullptr), static_cast<int32_t*>(nullptr),
+      num_items, 0, sizeof(KeyT) * 8, stream);
+
+  // Allocate workspace: temp_storage + alt_keys + alt_values (aligned)
+  size_t temp_aligned = align_up(temp_bytes, kAlignment);
+  size_t alt_keys_bytes = static_cast<size_t>(num_items) * sizeof(KeyT);
+  size_t alt_keys_aligned = align_up(alt_keys_bytes, kAlignment);
+  size_t alt_values_bytes = static_cast<size_t>(num_items) * sizeof(int32_t);
+  size_t total_bytes = temp_aligned + alt_keys_aligned + alt_values_bytes;
+  char* workspace = allocator.allocate(total_bytes);
+
+  void* d_temp = workspace;
+  KeyT* alt_keys = reinterpret_cast<KeyT*>(workspace + temp_aligned);
+  int32_t* alt_values = reinterpret_cast<int32_t*>(
+      workspace + temp_aligned + alt_keys_aligned);
+
+  cub::DoubleBuffer<KeyT> d_keys(keys, alt_keys);
+  cub::DoubleBuffer<int32_t> d_values(values, alt_values);
+
+  cub::DeviceRadixSort::SortPairs(
+      d_temp, temp_bytes, d_keys, d_values,
+      num_items, 0, sizeof(KeyT) * 8, stream);
+
+  // Copy back if result ended up in alt buffer
+  if (d_keys.Current() != keys) {
+    cudaMemcpyAsync(keys, d_keys.Current(),
+        num_items * sizeof(KeyT), cudaMemcpyDeviceToDevice, stream);
+  }
+  if (d_values.Current() != values) {
+    cudaMemcpyAsync(values, d_values.Current(),
+        num_items * sizeof(int32_t), cudaMemcpyDeviceToDevice, stream);
+  }
+
+  allocator.deallocate(workspace, total_bytes);
+}
+
+}  // namespace
+
 tv::Tensor SpconvOps::sort_1d_by_key_allocator_v2(tv::Tensor data, ThrustAllocator& allocator, tv::Tensor indices, std::uintptr_t stream, int mask_count, bool do_sort)   {
-  
+
   cudaStream_t stream_cu = reinterpret_cast<cudaStream_t>(stream);
   if (indices.empty()){
       indices = tv::empty({data.dim(0)}, tv::int32, 0);
@@ -36,67 +92,82 @@ tv::Tensor SpconvOps::sort_1d_by_key_allocator_v2(tv::Tensor data, ThrustAllocat
   if (!do_sort){
       return indices;
   }
-  // auto timer = tv::CUDATimer();
-  if (data.dtype() == tv::DType(1)){
-    using T_ = int32_t;
-    tv::dispatch_int<1, 2, 3, 4>(mask_count, [&](auto IV){
-        constexpr int I = TV_DECLTYPE(IV)::value;
-        // we can't use thrust::tuple in mp_repeat_c directly because
-        // thrust tuple actually has fixed size template arguments.
-        using T = tv::mp_rename<tv::mp_repeat_c<tv::mp_list<T_>, I>, thrust::tuple>;
-        thrust::device_ptr<T> ptr_tr(reinterpret_cast<T*>(data.data_ptr<T_>()));
-        thrust::device_ptr<int32_t> ptr_k(indices.data_ptr<int32_t>());
-        auto thrust_ctx = thrust::cuda::par.on(stream_cu);
-        auto ctx2 = thrust::cuda::par(allocator).on(stream_cu);
-        thrust::sort_by_key(ctx2, ptr_tr, ptr_tr + data.dim(0), ptr_k);
-    });
+
+  int num_items = data.dim(0);
+
+  if (mask_count == 1) {
+    // Use CUB radix sort (CUDA graph capture compatible)
+    if (data.dtype() == tv::DType(1)){
+      cub_sort_pairs(data.data_ptr<int32_t>(), indices.data_ptr<int32_t>(),
+                     num_items, allocator, stream_cu);
+    }
+    else if (data.dtype() == tv::DType(8)){
+      cub_sort_pairs(data.data_ptr<int64_t>(), indices.data_ptr<int32_t>(),
+                     num_items, allocator, stream_cu);
+    }
+    else if (data.dtype() == tv::DType(10)){
+      cub_sort_pairs(data.data_ptr<uint32_t>(), indices.data_ptr<int32_t>(),
+                     num_items, allocator, stream_cu);
+    }
+    else if (data.dtype() == tv::DType(11)){
+      cub_sort_pairs(data.data_ptr<uint64_t>(), indices.data_ptr<int32_t>(),
+                     num_items, allocator, stream_cu);
+    }
+    else{
+      TV_THROW_RT_ERR("unknown dtype data.dtype(), available: [int32_t, int64_t, uint32_t, uint64_t]")
+    }
   }
-  else if (data.dtype() == tv::DType(8)){
-    using T_ = int64_t;
-    tv::dispatch_int<1, 2, 3, 4>(mask_count, [&](auto IV){
-        constexpr int I = TV_DECLTYPE(IV)::value;
-        // we can't use thrust::tuple in mp_repeat_c directly because
-        // thrust tuple actually has fixed size template arguments.
-        using T = tv::mp_rename<tv::mp_repeat_c<tv::mp_list<T_>, I>, thrust::tuple>;
-        thrust::device_ptr<T> ptr_tr(reinterpret_cast<T*>(data.data_ptr<T_>()));
-        thrust::device_ptr<int32_t> ptr_k(indices.data_ptr<int32_t>());
-        auto thrust_ctx = thrust::cuda::par.on(stream_cu);
-        auto ctx2 = thrust::cuda::par(allocator).on(stream_cu);
-        thrust::sort_by_key(ctx2, ptr_tr, ptr_tr + data.dim(0), ptr_k);
-    });
+  else {
+    // mask_count > 1: fall back to thrust (rare case for kernel_volume > 32)
+    if (data.dtype() == tv::DType(1)){
+      using T_ = int32_t;
+      tv::dispatch_int<1, 2, 3, 4>(mask_count, [&](auto IV){
+          constexpr int I = TV_DECLTYPE(IV)::value;
+          using T = tv::mp_rename<tv::mp_repeat_c<tv::mp_list<T_>, I>, thrust::tuple>;
+          thrust::device_ptr<T> ptr_tr(reinterpret_cast<T*>(data.data_ptr<T_>()));
+          thrust::device_ptr<int32_t> ptr_k(indices.data_ptr<int32_t>());
+          auto ctx2 = thrust::cuda::par(allocator).on(stream_cu);
+          thrust::sort_by_key(ctx2, ptr_tr, ptr_tr + data.dim(0), ptr_k);
+      });
+    }
+    else if (data.dtype() == tv::DType(8)){
+      using T_ = int64_t;
+      tv::dispatch_int<1, 2, 3, 4>(mask_count, [&](auto IV){
+          constexpr int I = TV_DECLTYPE(IV)::value;
+          using T = tv::mp_rename<tv::mp_repeat_c<tv::mp_list<T_>, I>, thrust::tuple>;
+          thrust::device_ptr<T> ptr_tr(reinterpret_cast<T*>(data.data_ptr<T_>()));
+          thrust::device_ptr<int32_t> ptr_k(indices.data_ptr<int32_t>());
+          auto ctx2 = thrust::cuda::par(allocator).on(stream_cu);
+          thrust::sort_by_key(ctx2, ptr_tr, ptr_tr + data.dim(0), ptr_k);
+      });
+    }
+    else if (data.dtype() == tv::DType(10)){
+      using T_ = uint32_t;
+      tv::dispatch_int<1, 2, 3, 4>(mask_count, [&](auto IV){
+          constexpr int I = TV_DECLTYPE(IV)::value;
+          using T = tv::mp_rename<tv::mp_repeat_c<tv::mp_list<T_>, I>, thrust::tuple>;
+          thrust::device_ptr<T> ptr_tr(reinterpret_cast<T*>(data.data_ptr<T_>()));
+          thrust::device_ptr<int32_t> ptr_k(indices.data_ptr<int32_t>());
+          auto ctx2 = thrust::cuda::par(allocator).on(stream_cu);
+          thrust::sort_by_key(ctx2, ptr_tr, ptr_tr + data.dim(0), ptr_k);
+      });
+    }
+    else if (data.dtype() == tv::DType(11)){
+      using T_ = uint64_t;
+      tv::dispatch_int<1, 2, 3, 4>(mask_count, [&](auto IV){
+          constexpr int I = TV_DECLTYPE(IV)::value;
+          using T = tv::mp_rename<tv::mp_repeat_c<tv::mp_list<T_>, I>, thrust::tuple>;
+          thrust::device_ptr<T> ptr_tr(reinterpret_cast<T*>(data.data_ptr<T_>()));
+          thrust::device_ptr<int32_t> ptr_k(indices.data_ptr<int32_t>());
+          auto ctx2 = thrust::cuda::par(allocator).on(stream_cu);
+          thrust::sort_by_key(ctx2, ptr_tr, ptr_tr + data.dim(0), ptr_k);
+      });
+    }
+    else{
+      TV_THROW_RT_ERR("unknown dtype data.dtype(), available: [int32_t, int64_t, uint32_t, uint64_t]")
+    }
   }
-  else if (data.dtype() == tv::DType(10)){
-    using T_ = uint32_t;
-    tv::dispatch_int<1, 2, 3, 4>(mask_count, [&](auto IV){
-        constexpr int I = TV_DECLTYPE(IV)::value;
-        // we can't use thrust::tuple in mp_repeat_c directly because
-        // thrust tuple actually has fixed size template arguments.
-        using T = tv::mp_rename<tv::mp_repeat_c<tv::mp_list<T_>, I>, thrust::tuple>;
-        thrust::device_ptr<T> ptr_tr(reinterpret_cast<T*>(data.data_ptr<T_>()));
-        thrust::device_ptr<int32_t> ptr_k(indices.data_ptr<int32_t>());
-        auto thrust_ctx = thrust::cuda::par.on(stream_cu);
-        auto ctx2 = thrust::cuda::par(allocator).on(stream_cu);
-        thrust::sort_by_key(ctx2, ptr_tr, ptr_tr + data.dim(0), ptr_k);
-    });
-  }
-  else if (data.dtype() == tv::DType(11)){
-    using T_ = uint64_t;
-    tv::dispatch_int<1, 2, 3, 4>(mask_count, [&](auto IV){
-        constexpr int I = TV_DECLTYPE(IV)::value;
-        // we can't use thrust::tuple in mp_repeat_c directly because
-        // thrust tuple actually has fixed size template arguments.
-        using T = tv::mp_rename<tv::mp_repeat_c<tv::mp_list<T_>, I>, thrust::tuple>;
-        thrust::device_ptr<T> ptr_tr(reinterpret_cast<T*>(data.data_ptr<T_>()));
-        thrust::device_ptr<int32_t> ptr_k(indices.data_ptr<int32_t>());
-        auto thrust_ctx = thrust::cuda::par.on(stream_cu);
-        auto ctx2 = thrust::cuda::par(allocator).on(stream_cu);
-        thrust::sort_by_key(ctx2, ptr_tr, ptr_tr + data.dim(0), ptr_k);
-    });
-  }
-  else{
-    TV_THROW_RT_ERR("unknown dtype data.dtype(), available: [int32_t, int64_t, uint32_t, uint64_t]")
-  }
-  // tv::ssprint("SORT BY KEY TIME", data.dim(0), timer.report() / 1000.0);
+
   return indices;
 }
 } // namespace all

--- a/spconv/src/spconvlib/spconv/csrc/sparse/all/SpconvOps/SpconvOps_sort_1d_by_key_allocator_v2.cu
+++ b/spconv/src/spconvlib/spconv/csrc/sparse/all/SpconvOps/SpconvOps_sort_1d_by_key_allocator_v2.cu
@@ -29,6 +29,22 @@ using TensorViewKernel = spconvlib::cumm::common::TensorViewKernel;
 
 namespace {
 
+#define TV_CUB_CHECK(expr) \
+  do { \
+    cudaError_t __err = (expr); \
+    if (__err != cudaSuccess) { \
+      TV_THROW_RT_ERR("CUB error: ", cudaGetErrorString(__err)); \
+    } \
+  } while (0)
+
+#define TV_CUDA_CHECK(expr) \
+  do { \
+    cudaError_t __err = (expr); \
+    if (__err != cudaSuccess) { \
+      TV_THROW_RT_ERR("CUDA error: ", cudaGetErrorString(__err)); \
+    } \
+  } while (0)
+
 constexpr size_t kAlignment = 256;
 
 inline size_t align_up(size_t n, size_t alignment) {
@@ -40,11 +56,11 @@ void cub_sort_pairs(KeyT* keys, int32_t* values, int num_items,
                     ThrustAllocator& allocator, cudaStream_t stream) {
   // Query temp storage size
   size_t temp_bytes = 0;
-  cub::DeviceRadixSort::SortPairs(
+  TV_CUB_CHECK(cub::DeviceRadixSort::SortPairs(
       nullptr, temp_bytes,
       static_cast<const KeyT*>(nullptr), static_cast<KeyT*>(nullptr),
       static_cast<const int32_t*>(nullptr), static_cast<int32_t*>(nullptr),
-      num_items, 0, sizeof(KeyT) * 8, stream);
+      num_items, 0, sizeof(KeyT) * 8, stream));
 
   // Allocate workspace: temp_storage + alt_keys + alt_values (aligned)
   size_t temp_aligned = align_up(temp_bytes, kAlignment);
@@ -62,18 +78,18 @@ void cub_sort_pairs(KeyT* keys, int32_t* values, int num_items,
   cub::DoubleBuffer<KeyT> d_keys(keys, alt_keys);
   cub::DoubleBuffer<int32_t> d_values(values, alt_values);
 
-  cub::DeviceRadixSort::SortPairs(
+  TV_CUB_CHECK(cub::DeviceRadixSort::SortPairs(
       d_temp, temp_bytes, d_keys, d_values,
-      num_items, 0, sizeof(KeyT) * 8, stream);
+      num_items, 0, sizeof(KeyT) * 8, stream));
 
   // Copy back if result ended up in alt buffer
   if (d_keys.Current() != keys) {
-    cudaMemcpyAsync(keys, d_keys.Current(),
-        num_items * sizeof(KeyT), cudaMemcpyDeviceToDevice, stream);
+    TV_CUDA_CHECK(cudaMemcpyAsync(keys, d_keys.Current(),
+        static_cast<size_t>(num_items) * sizeof(KeyT), cudaMemcpyDeviceToDevice, stream));
   }
   if (d_values.Current() != values) {
-    cudaMemcpyAsync(values, d_values.Current(),
-        num_items * sizeof(int32_t), cudaMemcpyDeviceToDevice, stream);
+    TV_CUDA_CHECK(cudaMemcpyAsync(values, d_values.Current(),
+        static_cast<size_t>(num_items) * sizeof(int32_t), cudaMemcpyDeviceToDevice, stream));
   }
 
   allocator.deallocate(workspace, total_bytes);

--- a/spconv/src/spconvlib/spconv/csrc/sparse/all/SpconvOps/SpconvOps_sort_1d_by_key_allocator_v2.cu
+++ b/spconv/src/spconvlib/spconv/csrc/sparse/all/SpconvOps/SpconvOps_sort_1d_by_key_allocator_v2.cu
@@ -27,8 +27,6 @@ using Point2Voxel4D = spconvlib::spconv::csrc::sparse::all::ops4d::Point2Voxel;
 using CustomThrustLib = spconvlib::spconv::csrc::sparse::all::CustomThrustLib;
 using TensorViewKernel = spconvlib::cumm::common::TensorViewKernel;
 
-namespace {
-
 #define TV_CUB_CHECK(expr) \
   do { \
     cudaError_t __err = (expr); \
@@ -44,6 +42,8 @@ namespace {
       TV_THROW_RT_ERR("CUDA error: ", cudaGetErrorString(__err)); \
     } \
   } while (0)
+
+namespace {
 
 constexpr size_t kAlignment = 256;
 
@@ -98,7 +98,6 @@ void cub_sort_pairs(KeyT* keys, int32_t* values, int num_items,
 }  // namespace
 
 tv::Tensor SpconvOps::sort_1d_by_key_allocator_v2(tv::Tensor data, ThrustAllocator& allocator, tv::Tensor indices, std::uintptr_t stream, int mask_count, bool do_sort)   {
-
   cudaStream_t stream_cu = reinterpret_cast<cudaStream_t>(stream);
   if (indices.empty()){
       indices = tv::empty({data.dim(0)}, tv::int32, 0);
@@ -108,6 +107,7 @@ tv::Tensor SpconvOps::sort_1d_by_key_allocator_v2(tv::Tensor data, ThrustAllocat
   if (!do_sort){
       return indices;
   }
+  // auto timer = tv::CUDATimer();
 
   int num_items = data.dim(0);
 
@@ -183,7 +183,7 @@ tv::Tensor SpconvOps::sort_1d_by_key_allocator_v2(tv::Tensor data, ThrustAllocat
       TV_THROW_RT_ERR("unknown dtype data.dtype(), available: [int32_t, int64_t, uint32_t, uint64_t]")
     }
   }
-
+  // tv::ssprint("SORT BY KEY TIME", data.dim(0), timer.report() / 1000.0);
   return indices;
 }
 } // namespace all

--- a/spconv/src/spconvlib/spconv/csrc/sparse/all/SpconvOps/SpconvOps_sort_1d_by_key_split_allocator_v2.cu
+++ b/spconv/src/spconvlib/spconv/csrc/sparse/all/SpconvOps/SpconvOps_sort_1d_by_key_split_allocator_v2.cu
@@ -41,6 +41,22 @@ using TensorViewKernel = spconvlib::cumm::common::TensorViewKernel;
 
 namespace {
 
+#define TV_CUB_CHECK(expr) \
+  do { \
+    cudaError_t __err = (expr); \
+    if (__err != cudaSuccess) { \
+      TV_THROW_RT_ERR("CUB error: ", cudaGetErrorString(__err)); \
+    } \
+  } while (0)
+
+#define TV_CUDA_CHECK(expr) \
+  do { \
+    cudaError_t __err = (expr); \
+    if (__err != cudaSuccess) { \
+      TV_THROW_RT_ERR("CUDA error: ", cudaGetErrorString(__err)); \
+    } \
+  } while (0)
+
 constexpr size_t kAlignment = 256;
 
 inline size_t align_up(size_t n, size_t alignment) {
@@ -53,11 +69,11 @@ void cub_sort_pairs_masked(KeyT* keys, int32_t* values, int num_items,
                            ThrustAllocator& allocator, cudaStream_t stream) {
   // Query temp storage size
   size_t temp_bytes = 0;
-  cub::DeviceRadixSort::SortPairs(
+  TV_CUB_CHECK(cub::DeviceRadixSort::SortPairs(
       nullptr, temp_bytes,
       static_cast<const KeyT*>(nullptr), static_cast<KeyT*>(nullptr),
       static_cast<const int32_t*>(nullptr), static_cast<int32_t*>(nullptr),
-      num_items, 0, sizeof(KeyT) * 8, stream);
+      num_items, 0, sizeof(KeyT) * 8, stream));
 
   // Allocate workspace: temp_storage + masked_keys + alt_keys + alt_values (aligned)
   size_t temp_aligned = align_up(temp_bytes, kAlignment);
@@ -81,14 +97,14 @@ void cub_sort_pairs_masked(KeyT* keys, int32_t* values, int num_items,
   cub::DoubleBuffer<KeyT> d_keys(masked_keys, alt_keys);
   cub::DoubleBuffer<int32_t> d_values(values, alt_values);
 
-  cub::DeviceRadixSort::SortPairs(
+  TV_CUB_CHECK(cub::DeviceRadixSort::SortPairs(
       d_temp, temp_bytes, d_keys, d_values,
-      num_items, 0, sizeof(KeyT) * 8, stream);
+      num_items, 0, sizeof(KeyT) * 8, stream));
 
   // Copy values back if result ended up in alt buffer
   if (d_values.Current() != values) {
-    cudaMemcpyAsync(values, d_values.Current(),
-        num_items * sizeof(int32_t), cudaMemcpyDeviceToDevice, stream);
+    TV_CUDA_CHECK(cudaMemcpyAsync(values, d_values.Current(),
+        static_cast<size_t>(num_items) * sizeof(int32_t), cudaMemcpyDeviceToDevice, stream));
   }
 
   allocator.deallocate(workspace, total_bytes);

--- a/spconv/src/spconvlib/spconv/csrc/sparse/all/SpconvOps/SpconvOps_sort_1d_by_key_split_allocator_v2.cu
+++ b/spconv/src/spconvlib/spconv/csrc/sparse/all/SpconvOps/SpconvOps_sort_1d_by_key_split_allocator_v2.cu
@@ -2,19 +2,19 @@
 #include <spconvlib/spconv/csrc/sparse/all/CustomThrustLib.h>
 #include <spconvlib/cumm/common/TensorViewKernel.h>
 #include <spconvlib/spconv/csrc/sparse/all/cudakers/CudaCommonKernel.h>
+#include <cub/cub.cuh>
 
-        template <typename T> struct MaskedElementComp {
-            T mask_;
-            TV_HOST_DEVICE_INLINE T operator()(const T &x, const T &y) const {
-                return (x & mask_) < (y & mask_);
+        template <typename T> __global__ void apply_mask_kernel(const T* inp, T* out, T mask, int size){
+            for (int i : tv::KernelLoopX<int>(size)){
+                out[i] = inp[i] & mask;
             }
-        };
+        }
         template <typename T> __global__ void mask_input(T* inp, T mask, int size){
             for (int i : tv::KernelLoopX<int>(size)){
                 inp[i] &= mask;
             }
         }
-        
+
 namespace spconvlib {
 namespace spconv {
 namespace csrc {
@@ -38,29 +38,89 @@ using SpconvIndicesCPU4D = spconvlib::spconv::csrc::sparse::all::ops_cpu4d::Spar
 using Point2Voxel4D = spconvlib::spconv::csrc::sparse::all::ops4d::Point2Voxel;
 using CustomThrustLib = spconvlib::spconv::csrc::sparse::all::CustomThrustLib;
 using TensorViewKernel = spconvlib::cumm::common::TensorViewKernel;
+
+namespace {
+
+constexpr size_t kAlignment = 256;
+
+inline size_t align_up(size_t n, size_t alignment) {
+  return (n + alignment - 1) & ~(alignment - 1);
+}
+
+template <typename KeyT>
+void cub_sort_pairs_masked(KeyT* keys, int32_t* values, int num_items,
+                           KeyT mask_val, bool do_mask_output,
+                           ThrustAllocator& allocator, cudaStream_t stream) {
+  // Query temp storage size
+  size_t temp_bytes = 0;
+  cub::DeviceRadixSort::SortPairs(
+      nullptr, temp_bytes,
+      static_cast<const KeyT*>(nullptr), static_cast<KeyT*>(nullptr),
+      static_cast<const int32_t*>(nullptr), static_cast<int32_t*>(nullptr),
+      num_items, 0, sizeof(KeyT) * 8, stream);
+
+  // Allocate workspace: temp_storage + masked_keys + alt_keys + alt_values (aligned)
+  size_t temp_aligned = align_up(temp_bytes, kAlignment);
+  size_t key_bytes = static_cast<size_t>(num_items) * sizeof(KeyT);
+  size_t key_aligned = align_up(key_bytes, kAlignment);
+  size_t val_bytes = static_cast<size_t>(num_items) * sizeof(int32_t);
+  size_t total_bytes = temp_aligned + key_aligned + key_aligned + val_bytes;
+  char* workspace = allocator.allocate(total_bytes);
+
+  void* d_temp = workspace;
+  KeyT* masked_keys = reinterpret_cast<KeyT*>(workspace + temp_aligned);
+  KeyT* alt_keys = reinterpret_cast<KeyT*>(workspace + temp_aligned + key_aligned);
+  int32_t* alt_values = reinterpret_cast<int32_t*>(
+      workspace + temp_aligned + key_aligned + key_aligned);
+
+  // Apply mask to create sort keys
+  tv::cuda::Launch launcher(num_items, stream);
+  launcher(apply_mask_kernel<KeyT>, keys, masked_keys, mask_val, num_items);
+
+  // Sort masked keys with values (indices)
+  cub::DoubleBuffer<KeyT> d_keys(masked_keys, alt_keys);
+  cub::DoubleBuffer<int32_t> d_values(values, alt_values);
+
+  cub::DeviceRadixSort::SortPairs(
+      d_temp, temp_bytes, d_keys, d_values,
+      num_items, 0, sizeof(KeyT) * 8, stream);
+
+  // Copy values back if result ended up in alt buffer
+  if (d_values.Current() != values) {
+    cudaMemcpyAsync(values, d_values.Current(),
+        num_items * sizeof(int32_t), cudaMemcpyDeviceToDevice, stream);
+  }
+
+  allocator.deallocate(workspace, total_bytes);
+
+  // Optionally mask the original data
+  if (do_mask_output) {
+    launcher(mask_input<KeyT>, keys, mask_val, num_items);
+  }
+}
+
+}  // namespace
+
 tv::Tensor SpconvOps::sort_1d_by_key_split_allocator_v2(tv::Tensor data, ThrustAllocator& allocator, tv::Tensor mask, tv::Tensor indices, std::uintptr_t stream, bool mask_output)   {
-  
+
   cudaStream_t stream_cu = reinterpret_cast<cudaStream_t>(stream);
-  // auto timer = tv::CudaContextTimer<>();
   if (indices.empty()){
       indices = tv::empty({data.dim(0)}, tv::int32, 0);
   }
   tv::cuda::Launch launcher(data.dim(0), stream_cu);
   launcher(cudakers::arange_kernel<int32_t>, indices.data_ptr<int32_t>(), indices.dim(0));
+
+  int num_items = data.dim(0);
+
   tv::dispatch<int32_t, uint32_t, int64_t, uint64_t>(data.dtype(), [&](auto I){
       using T = TV_DECLTYPE(I);
       auto masks_ptr = mask.data_ptr<T>();
-      MaskedElementComp<T> op_comp{masks_ptr[0]};
-      thrust::device_ptr<T> ptr_tr(data.data_ptr<T>());
-      thrust::device_ptr<int32_t> ptr_k(indices.data_ptr<int32_t>());
-      // auto thrust_ctx = thrust::cuda::par.on(stream_cu);
-      auto ctx2 = thrust::cuda::par(allocator).on(stream_cu);
-      thrust::sort_by_key(ctx2, ptr_tr, ptr_tr + data.dim(0), ptr_k, op_comp);
-      if (mask_output){
-          launcher(mask_input<T>, data.data_ptr<T>(), masks_ptr[0], data.dim(0));
-      }
+      T mask_val = masks_ptr[0];
+      cub_sort_pairs_masked(data.data_ptr<T>(), indices.data_ptr<int32_t>(),
+                            num_items, mask_val, mask_output,
+                            allocator, stream_cu);
   });
-  // tv::ssprint("SORT_BY_KEY_MASKED", timer.report() / 1000.0);
+
   return indices;
 }
 } // namespace all

--- a/spconv/src/spconvlib/spconv/csrc/sparse/all/SpconvOps/SpconvOps_sort_1d_by_key_split_allocator_v2.cu
+++ b/spconv/src/spconvlib/spconv/csrc/sparse/all/SpconvOps/SpconvOps_sort_1d_by_key_split_allocator_v2.cu
@@ -102,8 +102,9 @@ void cub_sort_pairs_masked(KeyT* keys, int32_t* values, int num_items,
 }  // namespace
 
 tv::Tensor SpconvOps::sort_1d_by_key_split_allocator_v2(tv::Tensor data, ThrustAllocator& allocator, tv::Tensor mask, tv::Tensor indices, std::uintptr_t stream, bool mask_output)   {
-
+  
   cudaStream_t stream_cu = reinterpret_cast<cudaStream_t>(stream);
+  // auto timer = tv::CudaContextTimer<>();
   if (indices.empty()){
       indices = tv::empty({data.dim(0)}, tv::int32, 0);
   }
@@ -120,7 +121,7 @@ tv::Tensor SpconvOps::sort_1d_by_key_split_allocator_v2(tv::Tensor data, ThrustA
                             num_items, mask_val, mask_output,
                             allocator, stream_cu);
   });
-
+  // tv::ssprint("SORT_BY_KEY_MASKED", timer.report() / 1000.0);
   return indices;
 }
 } // namespace all

--- a/spconv/src/spconvlib/spconv/csrc/sparse/all/SpconvOps/SpconvOps_sort_1d_by_key_split_allocator_v2.cu
+++ b/spconv/src/spconvlib/spconv/csrc/sparse/all/SpconvOps/SpconvOps_sort_1d_by_key_split_allocator_v2.cu
@@ -39,8 +39,6 @@ using Point2Voxel4D = spconvlib::spconv::csrc::sparse::all::ops4d::Point2Voxel;
 using CustomThrustLib = spconvlib::spconv::csrc::sparse::all::CustomThrustLib;
 using TensorViewKernel = spconvlib::cumm::common::TensorViewKernel;
 
-namespace {
-
 #define TV_CUB_CHECK(expr) \
   do { \
     cudaError_t __err = (expr); \
@@ -56,6 +54,8 @@ namespace {
       TV_THROW_RT_ERR("CUDA error: ", cudaGetErrorString(__err)); \
     } \
   } while (0)
+
+namespace {
 
 constexpr size_t kAlignment = 256;
 

--- a/spconv/src/spconvlib/spconv/csrc/sparse/all/SpconvOps/SpconvOps_sort_1d_by_key_split_allocator_v2.cu
+++ b/spconv/src/spconvlib/spconv/csrc/sparse/all/SpconvOps/SpconvOps_sort_1d_by_key_split_allocator_v2.cu
@@ -14,6 +14,11 @@
                 inp[i] &= mask;
             }
         }
+        template <typename T> __global__ void gather_kernel(const T* src, const int32_t* indices, T* dst, int size){
+            for (int i : tv::KernelLoopX<int>(size)){
+                dst[i] = src[indices[i]];
+            }
+        }
 
 namespace spconvlib {
 namespace spconv {
@@ -75,12 +80,13 @@ void cub_sort_pairs_masked(KeyT* keys, int32_t* values, int num_items,
       static_cast<const int32_t*>(nullptr), static_cast<int32_t*>(nullptr),
       num_items, 0, sizeof(KeyT) * 8, stream));
 
-  // Allocate workspace: temp_storage + masked_keys + alt_keys + alt_values (aligned)
+  // Allocate workspace: temp_storage + masked_keys + alt_keys + alt_values + gather_tmp (aligned)
   size_t temp_aligned = align_up(temp_bytes, kAlignment);
   size_t key_bytes = static_cast<size_t>(num_items) * sizeof(KeyT);
   size_t key_aligned = align_up(key_bytes, kAlignment);
   size_t val_bytes = static_cast<size_t>(num_items) * sizeof(int32_t);
-  size_t total_bytes = temp_aligned + key_aligned + key_aligned + val_bytes;
+  size_t val_aligned = align_up(val_bytes, kAlignment);
+  size_t total_bytes = temp_aligned + key_aligned + key_aligned + val_aligned + key_bytes;
   char* workspace = allocator.allocate(total_bytes);
 
   void* d_temp = workspace;
@@ -88,6 +94,8 @@ void cub_sort_pairs_masked(KeyT* keys, int32_t* values, int num_items,
   KeyT* alt_keys = reinterpret_cast<KeyT*>(workspace + temp_aligned + key_aligned);
   int32_t* alt_values = reinterpret_cast<int32_t*>(
       workspace + temp_aligned + key_aligned + key_aligned);
+  KeyT* gather_tmp = reinterpret_cast<KeyT*>(
+      workspace + temp_aligned + key_aligned + key_aligned + val_aligned);
 
   // Apply mask to create sort keys
   tv::cuda::Launch launcher(num_items, stream);
@@ -101,15 +109,21 @@ void cub_sort_pairs_masked(KeyT* keys, int32_t* values, int num_items,
       d_temp, temp_bytes, d_keys, d_values,
       num_items, 0, sizeof(KeyT) * 8, stream));
 
-  // Copy values back if result ended up in alt buffer
+  // Copy values (indices) back if result ended up in alt buffer
   if (d_values.Current() != values) {
     TV_CUDA_CHECK(cudaMemcpyAsync(values, d_values.Current(),
         static_cast<size_t>(num_items) * sizeof(int32_t), cudaMemcpyDeviceToDevice, stream));
   }
 
+  // Gather data into sorted order to match old Thrust behavior
+  // (Thrust sort_by_key reorders both keys and values in-place)
+  launcher(gather_kernel<KeyT>, keys, values, gather_tmp, num_items);
+  TV_CUDA_CHECK(cudaMemcpyAsync(keys, gather_tmp,
+      static_cast<size_t>(num_items) * sizeof(KeyT), cudaMemcpyDeviceToDevice, stream));
+
   allocator.deallocate(workspace, total_bytes);
 
-  // Optionally mask the original data
+  // Optionally mask the original data (applied after reorder, matching old behavior)
   if (do_mask_output) {
     launcher(mask_input<KeyT>, keys, mask_val, num_items);
   }


### PR DESCRIPTION
In order to make spconv usable on NVIDIA DRIVE AGX Thor devkit, I made several changes.

- Replace Thrust `sort_by_key` with CUB `DeviceRadixSort::SortPairs` in `sort_1d_by_key_allocator_v2` and `sort_1d_by_key_split_allocator_v2` to enable CUDA graph capture compatibility (Thrust internally calls `cudaMalloc` which is not graph-safe)
- For `mask_count == 1` (common path), use CUB radix sort directly; retain Thrust fallback for `mask_count > 1` (rare case when kernel_volume > 32)
- Add compute capability 10.1 (NVIDIA DRIVE Thor / Jetson Thor) to the compiled GEMM architecture list