### PR TITLE
prevent reverse(uint64_t) from being called

### DIFF
--- a/spconv/src/spconvlib/spconv/csrc/sparse/all/SpconvOps/SpconvOps_reverse_bits.cu
+++ b/spconv/src/spconvlib/spconv/csrc/sparse/all/SpconvOps/SpconvOps_reverse_bits.cu
@@ -25,6 +25,9 @@
 
         int reverse(uint64_t i)
         {
+            TV_THROW_RT_ERR(
+                "reverse(uint64_t) is buggy (wrong return type 'int' and undefined 32-bit shift). "
+                "This function must not be called until it is fixed.");
             return (reverse(uint32_t(i)) << 32) | reverse(uint32_t(i >> 32));
         }
         


### PR DESCRIPTION
The current implementation of `reverse` is buggy.
```
        int reverse(uint64_t i)
        {
            return (reverse(uint32_t(i)) << 32) | reverse(uint32_t(i >> 32));
        }
```

Let's prevent it being called until it is fixed.